### PR TITLE
Replay captured body on partial read errors; dedupe sink registration

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -62,14 +62,14 @@ func prepareReqAndResp(c *echo.Context, config ZapConfig) (*response.Dumper, []b
 
 			reqBody, err = io.ReadAll(limitedReader)
 			if err != nil {
-				req.Body = originalBody
+				req.Body = restoreRequestBodyAfterReadError(originalBody, reqBody)
 			} else {
 				req.Body = restoreRequestBody(originalBody, reqBody, true)
 			}
 		} else {
 			reqBody, err = io.ReadAll(req.Body)
 			if err != nil {
-				req.Body = originalBody
+				req.Body = restoreRequestBodyAfterReadError(originalBody, reqBody)
 			} else {
 				_ = req.Body.Close()
 				// Reset original request body so it can be read again by handlers
@@ -94,6 +94,14 @@ func prepareReqAndResp(c *echo.Context, config ZapConfig) (*response.Dumper, []b
 	c.SetResponse(echoResp)
 
 	return respDumper, reqBody
+}
+
+func restoreRequestBodyAfterReadError(original io.ReadCloser, captured []byte) io.ReadCloser {
+	if len(captured) == 0 {
+		return original
+	}
+
+	return restoreRequestBody(original, captured, true)
 }
 
 // limitBytes truncates b to at most size bytes, trimming any trailing partial

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -90,6 +90,24 @@ func (errReadCloser) Close() error {
 	return nil
 }
 
+type partialErrReadCloser struct {
+	read bool
+}
+
+func (r *partialErrReadCloser) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+
+	r.read = true
+
+	return copy(p, "hello"), io.ErrUnexpectedEOF
+}
+
+func (*partialErrReadCloser) Close() error {
+	return nil
+}
+
 func TestPrepareReqAndResp_ReadErrorRestoresBody(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +124,25 @@ func TestPrepareReqAndResp_ReadErrorRestoresBody(t *testing.T) {
 	require.Empty(t, reqBody)
 	_, ok := ctx.Request().Body.(errReadCloser)
 	require.True(t, ok)
+}
+
+func TestPrepareReqAndResp_PartialReadErrorReplaysCapturedBody(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	req.Body = &partialErrReadCloser{}
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	respDumper, reqBody := prepareReqAndResp(ctx, ZapConfig{IsBodyDump: true})
+
+	require.NotNil(t, respDumper)
+	require.Equal(t, "hello", string(reqBody))
+
+	readBody, err := io.ReadAll(ctx.Request().Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(readBody))
 }
 
 func TestLimitBytes(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -145,6 +145,25 @@ func TestPrepareReqAndResp_PartialReadErrorReplaysCapturedBody(t *testing.T) {
 	require.Equal(t, "hello", string(readBody))
 }
 
+func TestPrepareReqAndResp_LimitHTTPBodyPartialReadErrorReplaysCapturedBody(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	req.Body = &partialErrReadCloser{}
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	respDumper, reqBody := prepareReqAndResp(ctx, ZapConfig{IsBodyDump: true, LimitHTTPBody: true, LimitSize: 1024})
+
+	require.NotNil(t, respDumper)
+	require.Equal(t, "hello", string(reqBody))
+
+	readBody, err := io.ReadAll(ctx.Request().Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(readBody))
+}
+
 func TestLimitBytes(t *testing.T) {
 	t.Parallel()
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,6 +42,12 @@ type MemorySink struct {
 func (*MemorySink) Close() error { return nil }
 func (*MemorySink) Sync() error  { return nil }
 
+var (
+	testMemorySink   = &MemorySink{new(bytes.Buffer)}
+	registerSinkOnce sync.Once
+	registerSinkErr  error
+)
+
 type MiddlewareTestSuite struct {
 	suite.Suite
 	sink         *MemorySink
@@ -52,17 +59,20 @@ type MiddlewareTestSuite struct {
 }
 
 func (s *MiddlewareTestSuite) SetupSuite() {
-	s.sink = &MemorySink{new(bytes.Buffer)}
-	err := zap.RegisterSink("memory", func(*url.URL) (zap.Sink, error) {
-		return s.sink, nil
+	s.sink = testMemorySink
+	registerSinkOnce.Do(func() {
+		registerSinkErr = zap.RegisterSink("memory", func(*url.URL) (zap.Sink, error) {
+			return testMemorySink, nil
+		})
 	})
-	s.Require().NoError(err)
+	s.Require().NoError(registerSinkErr)
 
 	conf := zap.NewDevelopmentConfig()
 	// Redirect all messages to the MemorySink.
 	conf.OutputPaths = []string{"memory://"}
-	s.logger, err = conf.Build()
+	logger, err := conf.Build()
 	s.Require().NoError(err)
+	s.logger = logger
 	s.ctxLogger = contextlogger.WithContext(s.logger, contextlogger.WithValueExtractor(requestID))
 }
 


### PR DESCRIPTION
## Summary

- When `io.ReadAll(req.Body)` returns an error after producing some bytes (e.g. `io.ErrUnexpectedEOF`), we previously replaced `req.Body` with the original `ReadCloser`, hiding the captured prefix from downstream handlers. Now we replay the captured bytes via a new `restoreRequestBodyAfterReadError` helper so handlers see the same content the middleware logged.
- `zap.RegisterSink` panics on duplicate scheme registration, which broke re-running `MiddlewareTestSuite`. Register the `memory` sink exactly once with `sync.Once` and share a single `MemorySink` across suite setups.
- Adds a unit test (`partialErrReadCloser`) covering the partial-read-error replay path.

## Test plan

- [ ] `go test -cover -race ./...`
- [ ] `go test -run TestPrepareReqAndResp_PartialReadErrorReplaysCapturedBody ./...`