### PR TITLE
Cap response dumper buffer when LimitHTTPBody is enabled

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -81,15 +81,20 @@ func prepareReqAndResp(c *echo.Context, config ZapConfig) (*response.Dumper, []b
 	// Set up response dumper
 	respWriter := c.Response()
 
+	limitDumperBytes := -1
+	if config.LimitHTTPBody && config.LimitSize > 0 {
+		limitDumperBytes = config.LimitSize
+	}
+
 	echoResp, err := echo.UnwrapResponse(respWriter)
 	if err != nil {
-		respDumper := response.NewDumper(respWriter)
+		respDumper := response.NewDumper(respWriter, response.WithMaxBytes(limitDumperBytes))
 		c.SetResponse(respDumper)
 
 		return respDumper, reqBody
 	}
 
-	respDumper := response.NewDumper(echoResp.ResponseWriter)
+	respDumper := response.NewDumper(echoResp.ResponseWriter, response.WithMaxBytes(limitDumperBytes))
 	echoResp.ResponseWriter = respDumper
 	c.SetResponse(echoResp)
 

--- a/helpers.go
+++ b/helpers.go
@@ -47,36 +47,8 @@ func prepareReqAndResp(c *echo.Context, config ZapConfig) (*response.Dumper, []b
 		return nil, nil
 	}
 
-	var reqBody []byte
-
 	req := c.Request()
-
-	// Capture request body if present
-	if req.Body != nil {
-		originalBody := req.Body
-
-		var err error
-
-		if config.LimitHTTPBody && config.LimitSize > 0 {
-			limitedReader := io.LimitReader(req.Body, int64(config.LimitSize)+1)
-
-			reqBody, err = io.ReadAll(limitedReader)
-			if err != nil {
-				req.Body = restoreRequestBodyAfterReadError(originalBody, reqBody)
-			} else {
-				req.Body = restoreRequestBody(originalBody, reqBody, true)
-			}
-		} else {
-			reqBody, err = io.ReadAll(req.Body)
-			if err != nil {
-				req.Body = restoreRequestBodyAfterReadError(originalBody, reqBody)
-			} else {
-				_ = req.Body.Close()
-				// Reset original request body so it can be read again by handlers
-				req.Body = restoreRequestBody(originalBody, reqBody, false)
-			}
-		}
-	}
+	reqBody := captureRequestBody(req, config)
 
 	// Set up response dumper
 	respWriter := c.Response()
@@ -99,6 +71,34 @@ func prepareReqAndResp(c *echo.Context, config ZapConfig) (*response.Dumper, []b
 	c.SetResponse(echoResp)
 
 	return respDumper, reqBody
+}
+
+func captureRequestBody(req *http.Request, config ZapConfig) []byte {
+	if req.Body == nil {
+		return nil
+	}
+
+	originalBody := req.Body
+	limited := config.LimitHTTPBody && config.LimitSize > 0
+
+	reader := io.Reader(req.Body)
+	if limited {
+		reader = io.LimitReader(req.Body, int64(config.LimitSize)+1)
+	}
+
+	reqBody, err := io.ReadAll(reader)
+	if err != nil {
+		req.Body = restoreRequestBodyAfterReadError(originalBody, reqBody)
+		return reqBody
+	}
+
+	if !limited {
+		_ = req.Body.Close()
+	}
+
+	req.Body = restoreRequestBody(originalBody, reqBody, limited)
+
+	return reqBody
 }
 
 func restoreRequestBodyAfterReadError(original io.ReadCloser, captured []byte) io.ReadCloser {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -164,6 +164,28 @@ func TestPrepareReqAndResp_LimitHTTPBodyPartialReadErrorReplaysCapturedBody(t *t
 	require.Equal(t, "hello", string(readBody))
 }
 
+func TestPrepareReqAndResp_NonEchoResponseWriter(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	// Swap the response for a writer that UnwrapResponse cannot resolve to *echo.Response.
+	ctx.SetResponse(response.NewDumper(rec))
+
+	respDumper, reqBody := prepareReqAndResp(ctx, ZapConfig{
+		IsBodyDump:    true,
+		LimitHTTPBody: true,
+		LimitSize:     4,
+	})
+
+	require.NotNil(t, respDumper)
+	require.Equal(t, "hello", string(reqBody))
+	require.Same(t, respDumper, ctx.Response())
+}
+
 func TestLimitBytes(t *testing.T) {
 	t.Parallel()
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -164,6 +164,21 @@ func TestPrepareReqAndResp_LimitHTTPBodyPartialReadErrorReplaysCapturedBody(t *t
 	require.Equal(t, "hello", string(readBody))
 }
 
+func TestPrepareReqAndResp_NilRequestBody(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req.Body = nil
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	respDumper, reqBody := prepareReqAndResp(ctx, ZapConfig{IsBodyDump: true})
+
+	require.NotNil(t, respDumper)
+	require.Nil(t, reqBody)
+}
+
 func TestPrepareReqAndResp_NonEchoResponseWriter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Pass `response.WithMaxBytes` to the response dumper so captured response bodies honor `ZapConfig.LimitSize` when `LimitHTTPBody` is set.
- Brings response-body capture in line with how request bodies are already truncated, avoiding buffering full responses in memory when the user opted into size limits.

## Test plan
- [x] `go test -cover -race ./...`
- [x] `golangci-lint run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)