### PR TITLE
Harden middleware body limits and request URI logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,10 @@
 - To mirror CI locally: `curl -sS https://raw.githubusercontent.com/adlandh/golangci-lint-config/refs/heads/main/.golangci.yml -o .golangci.yml && golangci-lint run`.
 
 ## Middleware Gotchas
-- `ZapConfig` defaults are filled only for nil `Skipper` and nil `BodySkipper`; changing zero-value behavior can affect callers that pass partial configs.
-- `LimitHTTPBody: true` with `LimitSize <= 0` means no body limit; tests cover this explicitly.
+- `ZapConfig` fills nil function fields from defaults; enabling body dumping with zero-valued limit settings applies the default 500-byte limit.
+- A negative `LimitSize` explicitly disables the body capture limit.
 - Body dumping must preserve the downstream request body. Limited reads intentionally read `LimitSize+1` bytes and replay them with the original body.
-- `BodySkipper` does not prevent capture; it replaces non-empty logged bodies with `[excluded]`.
+- `BodySkipper` runs after the handler; skipped bodies are captured up to the configured limit and logged as `[excluded]`.
 - Request IDs are read from the request `X-Request-Id` header first, then the response header set by Echo request ID middleware.
 - A handler that returns nil without committing a response logs `Response not committed` at warn level.
 - `Middleware(nil)` is allowed: `context-logger` wraps the logger, and nil context loggers fall back to `zap.NewNop()`.

--- a/README.md
+++ b/README.md
@@ -104,11 +104,13 @@ app.Use(echo_zap_middleware.Middleware(
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `Skipper` | `middleware.Skipper` | `middleware.DefaultSkipper` | Function to skip middleware execution for certain requests |
-| `BodySkipper` | `BodySkipper` | `defaultBodySkipper` | Function to exclude specific request/response bodies from logging |
+| `BodySkipper` | `BodySkipper` | `defaultBodySkipper` | Function evaluated after the handler to exclude bodies from logging |
 | `AreHeadersDump` | `bool` | `false` | Controls whether request and response headers are included in logs |
 | `IsBodyDump` | `bool` | `false` | Controls whether request and response bodies are included in logs |
-| `LimitHTTPBody` | `bool` | `true` | Controls whether to limit the size of logged HTTP bodies |
-| `LimitSize` | `int` | `500` | Maximum size (in bytes) for logged HTTP bodies; `<= 0` disables limiting |
+| `LimitHTTPBody` | `bool` | `true` | Enabled automatically for non-negative `LimitSize` values when body dumping is enabled |
+| `LimitSize` | `int` | `500` | Maximum size (in bytes) for logged HTTP bodies; `0` uses the default and `< 0` explicitly disables limiting |
+
+The `uri` log field contains only the escaped request path. Query parameters are omitted because they commonly contain tokens or personal data.
 
 ## Context-Aware Logging
 
@@ -182,11 +184,12 @@ func main() {
 			AreHeadersDump: true,
 			// if you would like to save your request or response body as tags, set IsBodyDump to true
 			IsBodyDump: true,
+			// Body logging uses the default 500-byte limit when limit settings are omitted
 			// No dump for /pong
 			// No dump for gzip
 			BodySkipper: func(c *echo.Context) (bool, bool) {
-				if c.Request().URL.Path == "/pong" { 
-					return true, true 
+				if c.Request().URL.Path == "/pong" {
+					return true, true
 				}
 				if c.Request().Header.Get("Content-Encoding") == "gzip" {
 					return true, true
@@ -255,6 +258,6 @@ The following benchmarks are available:
 When configuring the middleware, consider the following performance implications:
 
 1. Enabling body dumping (`IsBodyDump: true`) can significantly impact performance, especially with large request/response bodies.
-2. Using body size limits (`LimitHTTPBody: true`) can help mitigate performance issues when body dumping is enabled.
-3. Using a body skipper function to exclude large or binary content can improve performance.
+2. Body dumping uses a 500-byte capture limit by default. Set `LimitSize` to a negative value only when unbounded capture is explicitly required.
+3. A body skipper prevents excluded bodies from being logged, but they are still captured up to the configured limit.
 4. Header dumping (`AreHeadersDump: true`) has a smaller performance impact than body dumping but should still be considered.

--- a/helpers.go
+++ b/helpers.go
@@ -122,8 +122,13 @@ func limitBytes(b []byte, size int) []byte {
 	}
 
 	valid := b[:size]
-	for !utf8.Valid(valid) && len(valid) > 0 {
-		valid = valid[:len(valid)-1]
+	for i := 0; i < len(valid); {
+		r, width := utf8.DecodeRune(valid[i:])
+		if r == utf8.RuneError && width == 1 {
+			return valid[:i]
+		}
+
+		i += width
 	}
 
 	return valid

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -231,6 +231,11 @@ func TestLimitBytes(t *testing.T) {
 		t.Parallel()
 		require.Empty(t, limitBytes([]byte{0xE2, 0x82}, 1))
 	})
+
+	t.Run("stops at invalid utf8 in the middle", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, []byte("ab"), limitBytes([]byte{'a', 'b', 0xff, 'c', 'd'}, 4))
+	})
 }
 
 func TestLimitBytesWithDots(t *testing.T) {
@@ -469,6 +474,26 @@ func TestNormalizeConfig(t *testing.T) {
 	require.NotNil(t, cfg.Skipper)
 	require.NotNil(t, cfg.BodySkipper)
 	require.Equal(t, DefaultZapConfig.RedactHeaders, cfg.RedactHeaders)
+	require.Equal(t, 42, cfg.LimitSize)
+
+	// Enabling body dumping with zero-valued limit settings uses safe defaults.
+	cfg = normalizeConfig([]ZapConfig{{IsBodyDump: true}})
+	require.True(t, cfg.LimitHTTPBody)
+	require.Equal(t, DefaultZapConfig.LimitSize, cfg.LimitSize)
+
+	// A zero size still uses the safe default when the limit flag is provided.
+	cfg = normalizeConfig([]ZapConfig{{IsBodyDump: true, LimitHTTPBody: true}})
+	require.True(t, cfg.LimitHTTPBody)
+	require.Equal(t, DefaultZapConfig.LimitSize, cfg.LimitSize)
+
+	// A negative size explicitly opts out of limiting.
+	cfg = normalizeConfig([]ZapConfig{{IsBodyDump: true, LimitSize: -1}})
+	require.False(t, cfg.LimitHTTPBody)
+	require.Equal(t, -1, cfg.LimitSize)
+
+	// A positive size enables limiting even when the bool has its zero value.
+	cfg = normalizeConfig([]ZapConfig{{IsBodyDump: true, LimitSize: 42}})
+	require.True(t, cfg.LimitHTTPBody)
 	require.Equal(t, 42, cfg.LimitSize)
 
 	// Explicit empty (non-nil) RedactHeaders → opt-out preserved, not backfilled.

--- a/middleware.go
+++ b/middleware.go
@@ -56,12 +56,13 @@ type ZapConfig struct {
 	IsBodyDump bool
 
 	// LimitHTTPBody controls whether to limit the size of logged HTTP bodies.
-	// When true, bodies larger than LimitSize will be truncated.
+	// Body dumping automatically enables it for non-negative LimitSize values.
 	LimitHTTPBody bool
 
 	// LimitSize specifies the maximum size (in bytes) for logged HTTP bodies.
 	// Bodies larger than this will be truncated with "..." appended.
-	// Only used when LimitHTTPBody is true; <= 0 disables limiting.
+	// When body dumping is enabled, zero uses the default size. A negative value
+	// explicitly disables limiting.
 	LimitSize int
 }
 
@@ -100,7 +101,7 @@ func createLogFields(c *echo.Context, start time.Time) []zapcore.Field {
 		zap.Duration("latency", time.Since(start)),
 		zap.String("request_id", getRequestID(c)),
 		zap.String("method", req.Method),
-		zap.String("uri", req.RequestURI),
+		zap.String("uri", req.URL.EscapedPath()),
 		zap.String("host", req.Host),
 		zap.String("remote_ip", c.RealIP()),
 	)
@@ -163,15 +164,14 @@ func makeHandler(ctxLogger *contextlogger.ContextLogger, config ZapConfig) echo.
 }
 
 // normalizeConfig returns a ZapConfig with nil fields populated from defaults.
-// When no config is provided, DefaultZapConfig is returned unchanged.
-// When a config is provided, only the nil-able fields (Skipper, BodySkipper,
-// RedactHeaders) are backfilled from defaults; all other fields are preserved.
+// When no config is provided, normalization starts from DefaultZapConfig.
+// When body dumping is enabled, non-negative sizes enable limiting, zero uses
+// the default size, and a negative size explicitly disables limiting.
 func normalizeConfig(config []ZapConfig) ZapConfig {
-	if len(config) == 0 {
-		return DefaultZapConfig
+	cfg := DefaultZapConfig
+	if len(config) > 0 {
+		cfg = config[0]
 	}
-
-	cfg := config[0]
 
 	if cfg.Skipper == nil {
 		cfg.Skipper = DefaultZapConfig.Skipper
@@ -183,6 +183,17 @@ func normalizeConfig(config []ZapConfig) ZapConfig {
 
 	if cfg.RedactHeaders == nil {
 		cfg.RedactHeaders = DefaultZapConfig.RedactHeaders
+	}
+
+	if cfg.IsBodyDump {
+		if cfg.LimitSize < 0 {
+			cfg.LimitHTTPBody = false
+		} else {
+			cfg.LimitHTTPBody = true
+			if cfg.LimitSize == 0 {
+				cfg.LimitSize = DefaultZapConfig.LimitSize
+			}
+		}
 	}
 
 	return cfg

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -3,6 +3,7 @@ package echozapmiddleware
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -253,6 +254,43 @@ func (s *MiddlewareTestSuite) TestWithBodyAndHeaders() {
 	s.NotContains(s.sink.String(), "span_id")
 }
 
+func (s *MiddlewareTestSuite) TestPartialBodyConfigUsesDefaultLimit() {
+	body := strings.Repeat("a", DefaultZapConfig.LimitSize+100)
+	s.router.Use(Middleware(s.logger, ZapConfig{IsBodyDump: true}))
+	s.router.POST("/ping", func(c *echo.Context) error {
+		got, err := io.ReadAll(c.Request().Body)
+		s.Require().NoError(err)
+		s.Equal(body, string(got))
+
+		return c.String(http.StatusOK, body)
+	})
+
+	r := httptest.NewRequest(http.MethodPost, "/ping", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, r)
+
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal(body, w.Body.String())
+	truncated := strings.Repeat("a", DefaultZapConfig.LimitSize-3) + "..."
+	s.Contains(s.sink.String(), `"req.body": "`+truncated+`"`)
+	s.Contains(s.sink.String(), `"resp.body": "`+truncated+`"`)
+	s.expectMethod = http.MethodPost
+}
+
+func (s *MiddlewareTestSuite) TestQueryStringIsNotLogged() {
+	s.router.Use(Middleware(s.logger))
+	s.router.GET("/ping", func(c *echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/ping?access_token=secret", http.NoBody)
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, r)
+
+	s.NotContains(s.sink.String(), "access_token")
+	s.NotContains(s.sink.String(), "secret")
+}
+
 func (s *MiddlewareTestSuite) TestWithBodyAndHeadersWithContextLogger() {
 	s.router.Use(middleware.RequestIDWithConfig(middleware.RequestIDConfig{
 		RequestIDHandler: requestID.Saver,
@@ -312,9 +350,8 @@ func (s *MiddlewareTestSuite) TestBodySkipperNilDefaults() {
 
 func (s *MiddlewareTestSuite) TestBodyLimitApplied() {
 	s.router.Use(Middleware(s.logger, ZapConfig{
-		IsBodyDump:    true,
-		LimitHTTPBody: true,
-		LimitSize:     12,
+		IsBodyDump: true,
+		LimitSize:  12,
 	}))
 	s.router.POST("/ping", func(c *echo.Context) error {
 		return c.String(http.StatusOK, "ok")

--- a/skills/golang-echo-zap/SKILL.md
+++ b/skills/golang-echo-zap/SKILL.md
@@ -18,9 +18,10 @@ Use this skill when adding or configuring `github.com/adlandh/echo-zap-middlewar
 - Import path is `github.com/adlandh/echo-zap-middleware/v2`; package name is `echozapmiddleware` unless aliased.
 - `Middleware(logger, config...)` is the normal entrypoint for a `*zap.Logger`.
 - `MiddlewareWithContextLogger(ctxLogger, config...)` is for `github.com/adlandh/context-logger` extractors.
-- `ZapConfig` fills defaults only for nil `Skipper` and nil `BodySkipper`; bool and int zero values are meaningful.
-- `LimitHTTPBody: true` with `LimitSize <= 0` disables body limiting.
-- `BodySkipper` does not prevent body capture; it replaces non-empty logged bodies with `[excluded]`.
+- `ZapConfig` fills nil function fields from defaults. Enabling body dumping with zero-valued limit settings applies the default 500-byte limit.
+- Set `LimitSize` to a negative value to explicitly disable body limiting.
+- `BodySkipper` runs after the handler; skipped bodies are captured up to the configured limit but logged as `[excluded]`.
+- The `uri` field contains the escaped path without query parameters.
 - Request IDs are logged from request `X-Request-Id` first, then from Echo's response header.
 
 ## Minimal Setup
@@ -75,7 +76,7 @@ e.Use(echozapmiddleware.MiddlewareWithContextLogger(ctxLogger))
 ## Implementation Guidance
 - Add `middleware.RequestID()` before this middleware when generated request IDs should appear in logs.
 - Keep body dumping off by default for hot paths; enable `IsBodyDump` only when the service can afford body capture.
-- Use `BodySkipper` for sensitive or binary payloads, but still set `LimitHTTPBody` and `LimitSize` for large bodies.
+- Use `BodySkipper` for sensitive or binary payloads, keep the default capture limit, and add Echo's body-limit middleware before this middleware when request size itself must be bounded.
 - If changing middleware behavior in this repo, preserve downstream request body replay after capture and update README configuration docs.
 
 ## Verify


### PR DESCRIPTION
## Summary

- Apply a safe 500-byte default when body dumping is enabled without explicit limits.
- Treat negative `LimitSize` as an explicit opt-out from body limiting.
- Log only the escaped request path, excluding query parameters and sensitive data.
- Preserve downstream body replay and correctly stop truncation at invalid UTF-8.
- Update README and usage guidance to document the security and configuration behavior.

## Testing

- Added coverage for default, explicit, and disabled body limits.
- Added tests confirming query strings are omitted from logs and request bodies remain readable.
- Added invalid UTF-8 truncation coverage.