### PR TITLE
Preserve request and response bodies within the configured limit

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -151,10 +151,6 @@ func limitBytesWithDots(b []byte, size int) []byte {
 	}
 
 	truncated := limitBytes(b, size-3)
-	if len(truncated) == len(b) {
-		return b
-	}
-
 	out := make([]byte, len(truncated)+3)
 	copy(out, truncated)
 	copy(out[len(truncated):], "...")

--- a/helpers.go
+++ b/helpers.go
@@ -55,7 +55,7 @@ func prepareReqAndResp(c *echo.Context, config ZapConfig) (*response.Dumper, []b
 
 	limitDumperBytes := -1
 	if config.LimitHTTPBody && config.LimitSize > 0 {
-		limitDumperBytes = config.LimitSize
+		limitDumperBytes = config.LimitSize + 1
 	}
 
 	echoResp, err := echo.UnwrapResponse(respWriter)
@@ -142,6 +142,10 @@ func limitBytes(b []byte, size int) []byte {
 // missing truncation signal. Callers that need a visible indicator at small
 // sizes should configure a larger LimitSize.
 func limitBytesWithDots(b []byte, size int) []byte {
+	if len(b) <= size {
+		return b
+	}
+
 	if size <= 10 {
 		return limitBytes(b, size)
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -260,6 +260,15 @@ func TestLimitBytesWithDots(t *testing.T) {
 		t.Parallel()
 		require.Equal(t, []byte("short"), limitBytesWithDots([]byte("short"), 20))
 	})
+
+	t.Run("default limit preserves bodies that fit", func(t *testing.T) {
+		t.Parallel()
+
+		for size := DefaultZapConfig.LimitSize - 2; size <= DefaultZapConfig.LimitSize; size++ {
+			body := []byte(strings.Repeat("a", size))
+			require.Equal(t, body, limitBytesWithDots(body, DefaultZapConfig.LimitSize))
+		}
+	})
 }
 
 func TestLimitBody(t *testing.T) {


### PR DESCRIPTION
## Summary

- Read one extra byte when applying HTTP body limits so truncation is detected without altering bodies that fit.
- Preserve bodies at or below the configured limit when adding truncation markers.
- Add coverage for default-limit bodies that fit exactly.

## Testing

- Added unit coverage for body preservation at the default limit.
- Not run (not requested).